### PR TITLE
Fix modal video aspect ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,9 +304,8 @@
 
         /* Modal layout: video on the left, description on the right */
         .modal-video {
-            max-width: 100%;
             width: 100%;
-            height: auto;
+            height: 100%;
             border-radius: 10px;
         }
 


### PR DESCRIPTION
## Summary
- Ensure modal video iframes fill their container to maintain YouTube's 16:9 ratio across screen sizes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0394e5f6483259756d0c901f8e787