### PR TITLE
Remove hover preview and text fade from project boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,6 @@
             text-align: center;
             padding: 20px;
             background: var(--bg-color-box);
-            transition: opacity 0.3s ease;
         }
 
         .project-box .content h3 {
@@ -174,27 +173,7 @@
             font-size: clamp(1rem, 2.5vw, 1.25rem);
         }
 
-        .project-box .preview {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            opacity: 0;
-            pointer-events: none;
-            transition: opacity 0.3s ease;
-            z-index: 1;
-        }
-
-        .project-box:hover .preview {
-            opacity: 1;
-            pointer-events: auto;
-        }
-
-        .project-box:hover .content {
-            opacity: 0;
-        }
+        /* Preview on hover removed */
 
         /* Fullscreen canvas for 3D rendering */
         #canvas {
@@ -649,17 +628,13 @@
                 projectBox.setAttribute('data-images', JSON.stringify(project.images));
             }
             
-            const videoId = project.video.split('/').pop();
-            const thumbSrc = `https://img.youtube.com/vi/${videoId}/0.jpg`;
-
-            // Set the inner HTML for the project box (content and thumbnail)
+            // Set the inner HTML for the project box (content only)
             projectBox.innerHTML = `
                 <div class="content px-5">
                 <h3>${project.title}</h3>
                 <p class="descr mt-2">${project.shortDescription}</p>
                 <p class="mt-3">(Press for more)</p>
                 </div>
-                <img src="${thumbSrc}" class="preview" alt="${project.title} thumbnail">
             `;
             
             // Append the project box to the column and then the column to the container


### PR DESCRIPTION
## Summary
- Remove image preview and text fade on project boxes while retaining hover scale effect.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/portfolio/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b04e97e2a48325b408dba306a62b18