### PR TITLE
Extrude project card text in 3D

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,24 +164,17 @@
             text-align: center;
             padding: 20px;
             background: var(--bg-color-box);
-            transform: translateZ(30px);
             transform-style: preserve-3d;
         }
 
         .project-box .content h3 {
             font-size: clamp(1.25rem, 3.5vw, 2rem);
-            text-shadow:
-                1px 1px 0 var(--border-color),
-                2px 2px 0 var(--border-color),
-                3px 3px 0 var(--border-color);
+            transform-style: preserve-3d;
         }
 
         .project-box .content p {
             font-size: clamp(1rem, 2.5vw, 1.25rem);
-            text-shadow:
-                1px 1px 0 var(--border-color),
-                2px 2px 0 var(--border-color),
-                3px 3px 0 var(--border-color);
+            transform-style: preserve-3d;
         }
 
         /* Preview on hover removed */
@@ -606,6 +599,28 @@
         const btnCloseCarousel = document.getElementById('carouselClose');
 
 
+        // Helper to create 3D extruded text
+        function extrudeText(element, depth = 20) {
+            const text = element.textContent;
+            element.setAttribute('aria-label', text);
+            element.style.position = 'relative';
+            element.style.transformStyle = 'preserve-3d';
+            element.style.transform = `translateZ(${depth}px)`;
+            for (let i = 0; i < depth; i++) {
+                const span = document.createElement('span');
+                span.textContent = text;
+                span.style.position = 'absolute';
+                span.style.top = '0';
+                span.style.left = '0';
+                span.style.width = '100%';
+                span.style.display = 'block';
+                span.style.margin = '0';
+                span.style.transform = `translateZ(${i}px)`;
+                span.setAttribute('aria-hidden', 'true');
+                element.prepend(span);
+            }
+        }
+
         //Dynamic fetching of projects
         fetch('media/projects.json')
         .then(response => {
@@ -647,6 +662,9 @@
                 <p class="mt-3">(Press for more)</p>
                 </div>
             `;
+
+            // Extrude text inside the project box
+            projectBox.querySelectorAll('h3, p').forEach(el => extrudeText(el));
 
             // 3D tilt effect
             projectBox.style.transition = 'transform 0.2s ease';


### PR DESCRIPTION
## Summary
- Remove shadow-based styling from project cards and enable true 3D layout.
- Add utility to build layered text and translate it forward for an extruded look that moves with each card.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0621eeef88325b317a5806cb7bb5e