### PR TITLE
Use Three.js for genuine 3D project card text

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,6 @@
             overflow: hidden;
             background-color: var(--bg-color-box);
             cursor: pointer;
-            transform-style: preserve-3d;
         }
 
         .project-box .content {
@@ -164,17 +163,14 @@
             text-align: center;
             padding: 20px;
             background: var(--bg-color-box);
-            transform-style: preserve-3d;
         }
 
         .project-box .content h3 {
             font-size: clamp(1.25rem, 3.5vw, 2rem);
-            transform-style: preserve-3d;
         }
 
         .project-box .content p {
             font-size: clamp(1rem, 2.5vw, 1.25rem);
-            transform-style: preserve-3d;
         }
 
         /* Preview on hover removed */
@@ -581,8 +577,10 @@
         <p>&copy; 2025 Arz Abou Rached. Developed by yours truly.</p>
     </footer>
 
-    <!-- Include Bootstrap JS and Three.js -->
+    <!-- Include Three.js and helpers for 3D text, then Bootstrap JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/js/loaders/FontLoader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/js/geometries/TextGeometry.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
 
     <!-- Include your JavaScript code here -->
@@ -599,25 +597,48 @@
         const btnCloseCarousel = document.getElementById('carouselClose');
 
 
-        // Helper to create 3D extruded text
-        function extrudeText(element, depth = 20) {
-            const text = element.textContent;
+        // Helper to create 3D extruded text using Three.js
+        const fontLoader = new THREE.FontLoader();
+        let loadedFont = null;
+        function extrudeText(element, depth = 5) {
+            const text = element.textContent.trim();
             element.setAttribute('aria-label', text);
-            element.style.position = 'relative';
-            element.style.transformStyle = 'preserve-3d';
-            element.style.transform = `translateZ(${depth}px)`;
-            for (let i = 0; i < depth; i++) {
-                const span = document.createElement('span');
-                span.textContent = text;
-                span.style.position = 'absolute';
-                span.style.top = '0';
-                span.style.left = '0';
-                span.style.width = '100%';
-                span.style.display = 'block';
-                span.style.margin = '0';
-                span.style.transform = `translateZ(${i}px)`;
-                span.setAttribute('aria-hidden', 'true');
-                element.prepend(span);
+            element.textContent = '';
+            const width = element.clientWidth;
+            const height = element.clientHeight;
+
+            const renderer = new THREE.WebGLRenderer({ alpha: true });
+            renderer.setSize(width, height);
+            element.appendChild(renderer.domElement);
+
+            const scene = new THREE.Scene();
+            const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+            camera.position.z = 100;
+
+            const color = getComputedStyle(document.documentElement).getPropertyValue('--text-color-box').trim() || '#ffffff';
+
+            function renderText(font) {
+                const geometry = new THREE.TextGeometry(text, {
+                    font: font,
+                    size: height * 0.5,
+                    height: depth,
+                    curveSegments: 12,
+                    bevelEnabled: false
+                });
+                geometry.center();
+                const material = new THREE.MeshBasicMaterial({ color: color });
+                const mesh = new THREE.Mesh(geometry, material);
+                scene.add(mesh);
+                renderer.render(scene, camera);
+            }
+
+            if (loadedFont) {
+                renderText(loadedFont);
+            } else {
+                fontLoader.load('https://threejs.org/examples/fonts/helvetiker_regular.typeface.json', font => {
+                    loadedFont = font;
+                    renderText(font);
+                });
             }
         }
 
@@ -663,9 +684,6 @@
                 </div>
             `;
 
-            // Extrude text inside the project box
-            projectBox.querySelectorAll('h3, p').forEach(el => extrudeText(el));
-
             // 3D tilt effect
             projectBox.style.transition = 'transform 0.2s ease';
             projectBox.addEventListener('mousemove', (e) => {
@@ -683,6 +701,9 @@
             // Append the project box to the column and then the column to the container
             colDiv.appendChild(projectBox);
             projectsContainer.appendChild(colDiv);
+
+            // Extrude text inside the project box after it is added to the DOM
+            projectBox.querySelectorAll('h3, p').forEach(el => extrudeText(el));
             });
         })
         .catch(error => console.error('Error fetching projects:', error));


### PR DESCRIPTION
## Summary
- swap stacked text for real 3D extrusion via Three.js FontLoader and TextGeometry
- load Three.js helpers and remove old stacking CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0651007dc8325831ec15677cdcb72